### PR TITLE
FORD-156/fix-delete

### DIFF
--- a/src/Bonnier/WP/Cache/Models/Post.php
+++ b/src/Bonnier/WP/Cache/Models/Post.php
@@ -18,14 +18,13 @@ class Post
 
     public static function post_status_changed($new_status, $old_status, $post)
     {
-        if($old_status === 'draft' && $new_status === 'trash') {
+        if ($old_status === 'draft' && $new_status === 'trash') {
             return;
         }
 
-        if($new_status === 'publish'){
+        if ($new_status === 'publish') {
             self::update_post($post->ID);
-        }
-        elseif($new_status === 'trash'){
+        } elseif ($new_status === 'trash') {
             self::delete_post($post->ID);
         }
     }

--- a/src/Bonnier/WP/Cache/Models/Post.php
+++ b/src/Bonnier/WP/Cache/Models/Post.php
@@ -13,8 +13,21 @@ class Post
     {
         self::$settings = $settingsPage;
 
-        add_action('save_post', [__CLASS__, 'update_post']);
-        add_action('delete_post', [__CLASS__, 'delete_post']);
+        add_action('transition_post_status', [__CLASS__, 'post_status_changed'], 10, 3);
+    }
+
+    public static function post_status_changed($new_status, $old_status, $post)
+    {
+        if($old_status === 'draft' && $new_status === 'trash') {
+            return;
+        }
+
+        if($new_status === 'publish'){
+            self::update_post($post->ID);
+        }
+        elseif($new_status === 'trash'){
+            self::delete_post($post->ID);
+        }
     }
 
     public static function update_post($postId)

--- a/src/Bonnier/WP/Cache/Services/CacheApi.php
+++ b/src/Bonnier/WP/Cache/Services/CacheApi.php
@@ -38,12 +38,12 @@ class CacheApi
         if (!wp_is_post_revision($postID) && !wp_is_post_autosave($postID)) {
             $contentUrl = is_numeric($postID) ? get_permalink($postID) : '';
 
-            if($delete) {
+            if ($delete) {
                 global $post;
                 $postTerms = get_the_category($postID);
 
                 //Fix delete permalink.
-                if(isset($postTerms[0]) && $postTerms[0] instanceof \WP_Term) {
+                if (isset($postTerms[0]) && $postTerms[0] instanceof \WP_Term) {
                     $postCategory = $postTerms[0];
                     $categoryLink = get_category_link($postCategory->term_id);
                     $contentUrl = $categoryLink.'/'.$post->post_name;

--- a/src/Bonnier/WP/Cache/Services/CacheApi.php
+++ b/src/Bonnier/WP/Cache/Services/CacheApi.php
@@ -38,6 +38,18 @@ class CacheApi
         if (!wp_is_post_revision($postID) && !wp_is_post_autosave($postID)) {
             $contentUrl = is_numeric($postID) ? get_permalink($postID) : '';
 
+            if($delete) {
+                global $post;
+                $postTerms = get_the_category($postID);
+
+                //Fix delete permalink.
+                if(isset($postTerms[0]) && $postTerms[0] instanceof \WP_Term) {
+                    $postCategory = $postTerms[0];
+                    $categoryLink = get_category_link($postCategory->term_id);
+                    $contentUrl = $categoryLink.'/'.$post->post_name;
+                }
+            }
+
             $uri = $delete || !Post::is_published($postID) ? self::CACHE_DELETE : self::CACHE_UPDATE;
 
             return self::post($uri, $contentUrl);

--- a/src/Bonnier/WP/Cache/Settings/SettingsPage.php
+++ b/src/Bonnier/WP/Cache/Settings/SettingsPage.php
@@ -63,7 +63,7 @@ class SettingsPage
      */
     public function create_admin_page()
     {
-        // Set class property ?>
+        // Set class property?>
         <div class="wrap">
             <form method="post" action="options.php">
                 <?php

--- a/wp-bonnier-cache.php
+++ b/wp-bonnier-cache.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Bonnier Cache
  * Plugin URI: http://bonnierpublications.com
  * Description: Bonnier Cache Plugin
- * Version: 1.0.0
+ * Version: 1.1.0
  * Author: Magnus Flor
  * Author URI: http://bonnierpublications.com
  */


### PR DESCRIPTION
Use **transition_post_status** hook instead of delete_post & save_post :

- save_post : fires in different cases even when we don't actually save the post. e.g just pressing the 'Add new' post will fire save_post .. which makes a lot of unnecessary calls to inexistent URL's.

- delete_post : fires only when we delete the post from the trash. Once a post is moved to the trash WP addes '__trashed' to the permalink and the post will not be returned anymore by widgets. Which results in 404 for posts moved to trash. We need to call the delete endpoint when we move the post to trash. if the post is moved back to published we call update endpoint.

Fix permalink of deleted posts. As stated above wp already modify the url's just before they are trashed.